### PR TITLE
Short Stock mechanics + Gold Split rewards + misc fixes

### DIFF
--- a/ConfigValues.java
+++ b/ConfigValues.java
@@ -1,5 +1,7 @@
 package bbb;
 
+import java.io.File;
+
 public class ConfigValues {
 	// Class to hold and manage all configuration settings
 	
@@ -9,28 +11,41 @@ public class ConfigValues {
 	public static boolean cheekyEmotes;
 
 	public static double chokeRate;
+
+	public static int goldPayout;
+	public static double resetPayout;
+	public static double pbPayout;
 	
 	public static void writeValues() {
 		FileHandler.writeToFile("Config", "StocksOn:" + Boolean.toString(stocksOn) + FileHandler.nl
 								+ "ScoreMultiplier:" + Double.toString(scoreMultiplier) + FileHandler.nl
 								+ "DividendRate:" + Double.toString(dividendRate) + FileHandler.nl
 								+ "CheekyEmotes:" + Boolean.toString(cheekyEmotes) + FileHandler.nl
-								+ "ChokeRate:" + Double.toString(chokeRate) + FileHandler.nl);
+								+ "ChokeRate:" + Double.toString(chokeRate) + FileHandler.nl
+								+ "GoldPayout:" + Integer.toString(goldPayout) + FileHandler.nl   //Gold PB and Reset Payout are all in the config file, but not in the GUI.
+								+ "PBPayout:" + Double.toString(pbPayout) +FileHandler.nl 		  // This is a decision by me to avoid clutter, since I don't think people
+								+ "ResetPayout:" + Double.toString(resetPayout) +FileHandler.nl); // will edit them that much, but I still think they should be editable.
 	}
 	
 	public static void getValues() {
-		if(FileHandler.getFileLength("Config") > 3) {
+		if(FileHandler.getFileLength("Config") > 7) {
 			stocksOn = Boolean.parseBoolean(FileHandler.readFromFile("Config", 0).split(":")[1]);
 			scoreMultiplier = Double.parseDouble(FileHandler.readFromFile("Config", 1).split(":")[1]);
 			dividendRate = Double.parseDouble(FileHandler.readFromFile("Config", 2).split(":")[1]);
 			cheekyEmotes = Boolean.parseBoolean(FileHandler.readFromFile("Config", 3).split(":")[1]);
 			chokeRate = Double.parseDouble(FileHandler.readFromFile("Config", 4).split(":")[1]);
+			goldPayout = Integer.parseInt(FileHandler.readFromFile("Config", 5).split(":")[1]);
+			pbPayout = Double.parseDouble(FileHandler.readFromFile("Config", 6).split(":")[1]);
+			resetPayout = Double.parseDouble(FileHandler.readFromFile("Config", 7).split(":")[1]);
 		}
 		else {
 			stocksOn = true;
 			scoreMultiplier = 10.0;
 			dividendRate = 0.5; //for some reason it was 5.0 points per second before
-			chokeRate = 0.75;
+			chokeRate = 0.85;
+			goldPayout = 100;
+			pbPayout = 2.0;
+			resetPayout = 0.75;
 			cheekyEmotes = true;
 			writeValues();
 		}

--- a/LiveSplitHandler.java
+++ b/LiveSplitHandler.java
@@ -72,9 +72,13 @@ public class LiveSplitHandler {
 	}
 
 	public static String getDelta() {
-		// Get the current delta with current comparison
+		// Get the current delta for PB (changed because I switch between comparisons sometimes, but still want the bot to be only on PB.)
 
-		return receive("getdelta");
+		return receive("getdelta Personal Best");
+	}
+
+	public static String getBestDelta() {
+		return receive("getdelta Best Segments");
 	}
 
 	public static String getSplitIndex() {

--- a/PlayersHandler.java
+++ b/PlayersHandler.java
@@ -11,7 +11,7 @@ public class PlayersHandler {
 	public static class Player {
 		public String name;
 		public int points;
-		public int state; // 0 - not invested, 1 - invested, 2 - waiting to sell
+		public int state; // 0 - not invested, 1 - invested, 2 - waiting to sell, 3 - shorting a stock
 		public int investment; // amount invested
 		public int beginSplit; // The split in which this player was invested when the split began. To be updated at each split.
 	}

--- a/PlayersHandler.java
+++ b/PlayersHandler.java
@@ -68,7 +68,15 @@ public class PlayersHandler {
 		} else
 			return false;
 	}
-
+	public static int getNumActivePlayers() {
+		int numActivePlayers = 0;
+		for(int i = 0; i < players.size(); i++) {
+			if(players.get(i).state != 0) {
+				numActivePlayers++;
+			}
+		}
+		return numActivePlayers;
+	}
 	public static void saveAll() {
 
 		try {

--- a/PointsGameHandler.java
+++ b/PointsGameHandler.java
@@ -22,13 +22,36 @@ public class PointsGameHandler {
 					players.get(i).investment = SplitGame.getCost();
 					PlayersHandler.saveAll();
 					return true;
+				} else if (players.get(i).points - SplitGame.getCost() > 0 && players.get(i).state == 3) { // buying after a short
+					players.get(i).points -= SplitGame.getCost();
+					players.get(i).state = 0;
+					players.get(i).investment = 0;
+					PlayersHandler.saveAll();
+					return true;
 				}
 			}
 		}
 
 		return false;
 	}
+	public static boolean shortRun(String newName) {//separate function from sell because I don't want people shorting accidentally.
 
+		ArrayList<Player> players = PlayersHandler.getPlayers();
+
+		for (int i = 0; i < players.size(); i++) {
+			if (players.get(i).name.equals(newName)) {
+				if (players.get(i).state == 0) {
+					players.get(i).points += SplitGame.getCost();
+					players.get(i).state = 3; // used 3 since 2 is going to be used for delayed selling
+					players.get(i).investment = -SplitGame.getCost();
+					PlayersHandler.saveAll();
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
 	public static boolean sellRun(String newName) {
 
 		ArrayList<Player> players = PlayersHandler.getPlayers();
@@ -68,7 +91,15 @@ public class PointsGameHandler {
 				players.get(i).points += payout;
 				players.get(i).state = 0;
 				players.get(i).investment = 0;
+			} else if(players.get(i).state == 3) { //shorting
+				int payout = SplitGame.getCost();
+				TwitchChat.outsidePM(players.get(i).name, "RIP run... You have to buy the stock back at the price of "
+						+ payout + " points for a result of " + (-payout - players.get(i).investment));
+				players.get(i).points -= payout;
+				players.get(i).state = 0;
+				players.get(i).investment = 0;
 			}
+
 		}
 
 		PlayersHandler.saveAll();

--- a/PointsGameHandler.java
+++ b/PointsGameHandler.java
@@ -129,4 +129,17 @@ public class PointsGameHandler {
 		PlayersHandler.saveAll();
 	}
 
+	public static void addGoldPayout() {
+		ArrayList<Player> players = PlayersHandler.getPlayers();
+
+		for(int i = 0; i < players.size(); i++) {
+
+			if(players.get(i).state == 1) // check if bought at all. mid-split shouldnt matter for this, as its hard to tell (if you have good splits) if a split will be a gold until right before you split.
+			{
+				players.get(i).points += ConfigValues.goldPayout;
+				TwitchChat.outsidePM(players.get(i).name, "GOOOOOOOOOOOOOLD!!!! Enjoy a payout of " + ConfigValues.goldPayout + " points!");
+			}
+		}
+	}
+
 }

--- a/ServerUpdate.java
+++ b/ServerUpdate.java
@@ -60,7 +60,7 @@ public class ServerUpdate implements Runnable{
         try {
             ssh.newSCPFileTransfer().upload(new FileSystemFile(filename), "/home/ben/Desktop/SpeedrunStocksServer");
         } catch (Exception e) {
-            System.err.println("ServerUpdate.updateFile(1) error : " + e.toString());
+            //System.err.println("ServerUpdate.updateFile(1) error : " + e.toString()); this seems like a thing specifically for bean and its clogging up my console
         }
     }
 

--- a/TwitchChat.java
+++ b/TwitchChat.java
@@ -114,6 +114,23 @@ public class TwitchChat extends PircBot {
 				}
 			}
 		}
+
+		if (message.equalsIgnoreCase("!short") && ConfigValues.stocksOn) {
+			boolean shorted = PointsGameHandler.shortRun(sender);
+			if (shorted)
+				privateMessage(sender, "Thanks for shorting, " + sender + "! It gave you " + SplitGame.getCost()
+						+ " points. You now have " + PlayersHandler.getPoints(sender) + " points. You will need to buy back, eventually, though.");
+			else {
+				if(!PlayersHandler.playing(sender))
+					messageChat(sender + ", first you gotta !join.");
+				else {
+					if(PlayersHandler.getState(sender) == 1)
+						privateMessage(sender, sender + ", first you need to !sell your current stock in order to short.");
+					else
+						privateMessage(sender, "Sorry, " + sender + ", but failed to short... D:");
+				}
+			}
+		}
 		
 		if (message.equalsIgnoreCase("!points")) {
 			if(!PlayersHandler.playing(sender))
@@ -121,6 +138,13 @@ public class TwitchChat extends PircBot {
 			else
 				messageChat(sender + " has " + PlayersHandler.getPoints(sender) + 
 						" points (Rank #" + PlayersHandler.getPlacement(sender) + ")");
+		}
+
+		if(message.equalsIgnoreCase(("!shorthelp"))) {
+			messageChat("Implementing a brand new \"short\" system. Basically, when you 'sell' a short, you're betting the run will fail. If you type !short, you sell a stock. " +
+						"You get all the points immediately, but you owe the system a stock, and will have to buy it back later. If the run resets, and you have a short, you " +
+						"will automatically buy back the stock at the reset value (0.75x normal price). Otherwise, you can use !buy to buy back the short. If you want to buy " +
+						"a normal stock after shorting a stock, you need to type !buy twice.");
 		}
 	}
 	
@@ -134,6 +158,12 @@ public class TwitchChat extends PircBot {
 						+ "!summary. To view all of the commands, message me !commands. Only "
 						+ "!buy, !sell and !points will work in the main chat - everything "
 						+ "else must be done through whsipers.");
+			}
+			if(message.equalsIgnoreCase(("!shorthelp"))) {
+				messageChat("Implementing a brand new \"short\" system. Basically, when you 'sell' a short, you're betting the run will fail. If you type !short, you sell a stock. " +
+						"You get all the points immediately, but you owe the system a stock, and will have to buy it back later. If the run resets, and you have a short, you " +
+						"will automatically buy back the stock at the reset value (0.75x normal price). Otherwise, you can use !buy to buy back the short. If you want to buy " +
+						"a normal stock after shorting a stock, you need to type !buy twice.");
 			}
 			
 			if (message.equalsIgnoreCase("!summary")) {
@@ -204,6 +234,23 @@ public class TwitchChat extends PircBot {
 							privateMessage(sender, sender + ", first you need to !buy");
 						else
 							privateMessage(sender, "Sorry, " + sender + ", but failed to sell... D:");
+					}
+				}
+			}
+
+			if (message.equalsIgnoreCase("!short") && ConfigValues.stocksOn) {
+				boolean shorted = PointsGameHandler.shortRun(sender);
+				if (shorted)
+					privateMessage(sender, "Thanks for shorting, " + sender + "! It gave you " + SplitGame.getCost()
+							+ " points. You now have " + PlayersHandler.getPoints(sender) + " points. You will need to buy back, eventually, though.");
+				else {
+					if(!PlayersHandler.playing(sender))
+						messageChat(sender + ", first you gotta !join.");
+					else {
+						if(PlayersHandler.getState(sender) == 1)
+							privateMessage(sender, sender + ", first you need to !sell your current stock in order to short.");
+						else
+							privateMessage(sender, "Sorry, " + sender + ", but failed to short... D:");
 					}
 				}
 			}


### PR DESCRIPTION
Short stock mechanic:

You can now "short" a speedrun by typing !short.
When you short a speedrun, you are betting that the run will get worse. How shorting a stock works is if you type !short, you'll "sell" a stock you dont actually own. You'll get the points for the stock, but you must buy the stock back before the run ends, or if the run resets, you'll automatically buy the stock back (at 75% of the price (can be changed now, see misc fixes), so worth it usually to wait until a reset)

Gold Split rewards:

Whenever gold splits occur, you can set a certain amount of points to be awarded to every investor who is currently invested.

Misc fixes:

Added a few config options for pb and reset stock price cuts/raises. (same for gold split reward amount)
The above three options are only editable by changing Config.txt, this is because I don't want to overclutter the GUI.

getDelta now only gets delta from PB, so if you switch your comparisons, the dividends arent all messed up

Removed the console clog created by the bot trying to access Bean's personal server

Fixed the anti-spam code for resets and dividends
